### PR TITLE
Use `vinyl-to-stream` instead of manually converting vinyl

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "glob": "^4.0.6",
         "imagemin": "^2.0.1",
         "raptor-async": "^1.0.1",
-        "through2": "^0.6.3"
+        "vinyl-to-stream": "^1.0.0"
     },
     "devDependencies": {
         "chai": "~1.8.1",


### PR DESCRIPTION
This is a nicer way to convert the vinyl stream to a regular text stream. We're going to implement this functionality in imagemin directly so this won't be needed in the future but it'll work for now.
